### PR TITLE
News 5

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -71,6 +71,18 @@ describe('app', () => {
                     )
                 })
         });
+        test('status:200 - responds with object containing comment count when article has no comments', () => {
+            return request(app)
+                .get('/api/articles/2')
+                .expect(200)
+                .then(({ body: { article } }) => {
+                    expect(article).toEqual(
+                        expect.objectContaining({
+                            comment_count: 0
+                        })
+                    )
+                })
+        });
         test('status:404 - responds with "Resource does not exist"', () => {
             return request(app)
                 .get('/api/articles/9999999')

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -46,15 +46,29 @@ describe('app', () => {
                 .get('/api/articles/3')
                 .expect(200)
                 .then(({ body: { article } }) => {
-                    expect(article).toEqual({
-                        article_id: 3,
-                        title: "Eight pug gifs that remind me of mitch",
-                        topic: "mitch",
-                        author: "icellusedkars",
-                        body: "some gifs",
-                        created_at: expect.any(String),
-                        votes: 0
-                    })
+                    expect(article).toEqual(
+                        expect.objectContaining({
+                            article_id: 3,
+                            title: "Eight pug gifs that remind me of mitch",
+                            topic: "mitch",
+                            author: "icellusedkars",
+                            body: "some gifs",
+                            created_at: expect.any(String),
+                            votes: 0
+                        })
+                    )
+                })
+        });
+        test('status:200 - responds with object containing comment count', () => {
+            return request(app)
+                .get('/api/articles/1')
+                .expect(200)
+                .then(({ body: { article } }) => {
+                    expect(article).toEqual(
+                        expect.objectContaining({
+                            comment_count: 11
+                        })
+                    )
                 })
         });
         test('status:404 - responds with "Resource does not exist"', () => {

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -2,7 +2,10 @@ const db = require('../db/connection');
 
 exports.selectArticleById = async (articleId) => {
     const article = await db.query(`
-        SELECT * FROM articles WHERE article_id = $1;
+    SELECT articles.article_id, title, topic, articles.author, articles.body, articles.created_at, articles.votes, CAST(COUNT(comments.article_id) AS INT) AS comment_count 
+    FROM articles 
+    LEFT JOIN comments ON articles.article_id = comments.article_id  WHERE articles.article_id = $1 
+    GROUP BY articles.article_id;
     `, [articleId]);
 
     if (article.rows.length === 0) {


### PR DESCRIPTION
- Add `comment_count` to query
- Refactor previous 200 test to use `expect.objectContaining()`
- Test response object contains `comment_count` property
- Test `comment_count = 0` when article has no associated comments